### PR TITLE
sentinel fixes for 60x

### DIFF
--- a/lib/config.py
+++ b/lib/config.py
@@ -11,7 +11,7 @@ default_sentinel_config = os.path.normpath(
 sentinel_config_file = os.environ.get('SENTINEL_CONFIG', default_sentinel_config)
 sentinel_cfg = energi_config.EnergiConfig.tokenize(sentinel_config_file)
 sentinel_version = "1.1.0"
-min_energid_proto_version_with_sentinel_ping = 70207
+min_energid_proto_version_with_sentinel_ping = 70209
 
 
 def get_energi_conf():

--- a/lib/energi_config.py
+++ b/lib/energi_config.py
@@ -34,7 +34,7 @@ class EnergiConfig():
         creds = {key: value for (key, value) in match}
 
         # standard Energi defaults, to accomodate all three networks (mainnet, testnet and testnet60x)
-        default_port = 9796 if (network == 'mainnet') else 19796 if (network == 'testnet') else 19766
+        default_port = 9796 if (network == 'mainnet') else 19796 if (network == 'testnet') else 29796 if (network == 'testnet60x') else 19766
 
         # use default port for network if not specified in energi.conf
         if not ('port' in creds):


### PR DESCRIPTION
* added default RPC port for testnet60x
* bumped minimum version for sentinelping which is not yet implemented in Energi