### PR TITLE
fixes for vote maturity & block timing

### DIFF
--- a/lib/energid.py
+++ b/lib/energid.py
@@ -160,9 +160,11 @@ class EnergiDaemon():
 
     def is_govobj_maturity_phase(self):
         # 3-day period for govobj maturity
-        maturity_phase_delta = 1662      # ~(60*24*3)/2.6
+        maturity_phase_delta = 4320      # ~(60*24*3)
         if config.network == 'testnet':
-            maturity_phase_delta = 24    # testnet
+            maturity_phase_delta = 30    # testnet
+        else if config.network == 'testnet60x'
+            maturity_phase_delta = 60    # testnet60x
 
         event_block_height = self.next_superblock_height()
         maturity_phase_start_block = event_block_height - maturity_phase_delta

--- a/lib/energilib.py
+++ b/lib/energilib.py
@@ -302,4 +302,4 @@ def blocks_to_seconds(blocks):
     Return the estimated number of seconds which will transpire for a given
     number of blocks.
     """
-    return blocks * 2.62 * 60
+    return blocks * 60


### PR DESCRIPTION
* sentinel block timing was incorrect
* vote maturity for superblocks happens at 3 days until superblock on the mainnet, instantly on the testnets